### PR TITLE
[WIP] build abundance CSV with hash as columns, datasets as rows

### DIFF
--- a/sourmap_rs/src/main.rs
+++ b/sourmap_rs/src/main.rs
@@ -107,7 +107,7 @@ fn abundance_matrix<P: AsRef<Path>>(
         let search_sigs = read_paths(siglist)?;
         info!("Loaded {} sig paths in siglist", search_sigs.len());
 
-        RevIndex::new(&search_sigs, &template, 0, None, false)
+        RevIndex::new(&search_sigs, &template, 0, None, true)
     } else {
         RevIndex::load(siglist, None)?
     };


### PR DESCRIPTION
I don't think this PR should be merged, even if it now generated the CSV in the right orientation. This PR is using the RevIndex for keeping track of all hashes, but reads counts for each dataset directly from the signatures, so might as well just build a large `BTreeSet` for the hashes instead of the full RevIndex?

The point I'm trying to make: the `RevIndex` was modified to support this use case, but I think it still works better for a full solution in Rust if it was defined previously (as a sparse proxy for the full matrix). But I wanted to keep it visible, depending on where the project goes we might merge or not =]